### PR TITLE
remove requestAnimationFrame polyfill attempt

### DIFF
--- a/src/animationframes.js
+++ b/src/animationframes.js
@@ -77,7 +77,3 @@ export const frames = (delay, duration) => {
   };
   return self;
 };
-
-window.requestAnimationFrame || (window.requestAnimationFrame = (cb) => {
-  setTimeout(cb, 0);
-});


### PR DESCRIPTION
I don't think the polyfill should be here for a number of reasons. Most of the browsers today do support `requestAnimationFrame` natively, so in many cases we are safe to assume that the user should have one, and this is not needed. When needed we can ask the user themselves to do it, since it doesn't seem to be the major focus of this library.

The polyfill also hurts more than benefit, since it's going to cause unnecessary iterations and hog the cpu, as the frame rate of the computer may vary a lot. Considering a computer has a frame rate of 60fps, it'll have to paint a frame every 1000/60 second but this assumes a next frame is called on the very next iteration of the event loop which is not realistic.  

A smarter polyfill which also make amends to the frame rate and how frequently setTimeout is called based on the previous iteration is the one mentioned on Paul Irish's [blog post](https://www.paulirish.com/2011/requestanimationframe-for-smart-animating/) about `requestAnimationFrame`.